### PR TITLE
#168371110 Fix Bug on Reset a Password

### DIFF
--- a/src/components/Auth/ResetPassword.jsx
+++ b/src/components/Auth/ResetPassword.jsx
@@ -51,6 +51,18 @@ export class ResetPassword extends Component {
 
     const { submittedSuccess, submittedFailure } = this.props;
 
+    if (submittedSuccess) {
+      setTimeout(() => this.setState({
+        email: '',
+      }), 2000);
+    }
+
+    if (submittedSuccess) {
+      setTimeout(() => this.setState({
+        submittedSuccess: true,
+      }), 5000);
+    }
+
     return (
       <Fragment>
         <TopNavbar />

--- a/src/components/Auth/ResettingPassword.jsx
+++ b/src/components/Auth/ResettingPassword.jsx
@@ -1,5 +1,6 @@
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
+import { Redirect } from 'react-router-dom';
 import Validator from '../../utils/resetPswdValidation';
 import { resettingPassword } from '../../redux/actions/actionCreators/resettingPassword';
 import '../../assets/scss/resetPassword.scss';
@@ -12,6 +13,7 @@ export class ResettingPassword extends Component {
     confirmPassword: '',
     passwordError: '',
     confirmPasswordError: '',
+    redirecting: false,
   };
 
   handleOnChange = e => {
@@ -63,6 +65,16 @@ export class ResettingPassword extends Component {
     } = this.state;
 
     const { resetSuccess, resetFailure } = this.props;
+
+    if (resetSuccess) {
+      setTimeout(() => this.setState({
+        redirecting: true,
+      }), 2000);
+    }
+
+    if (this.state.redirecting) {
+      return <Redirect to="/login" />;
+    }
 
     return (
       <Fragment>


### PR DESCRIPTION
#### What does this PR do?
- Ensure a user to redirect to log in page after resetting a password
#### Description of Task to be completed
- Enable a user to redirect to log in page after resetting a password

#### How should this be manually tested?
1. Run the following commands in the terminal
```
git clone https://github.com/andela/ah-92explorers-frontend.git
cd ah-92explorers-frontend
git checkout bg-fix-reset-password-168371110
configure .env file `APP_URL_BACKEND and CRYPTO_PASSWORD` values

npm install

npm run dev
```
- Browser to: `http://localhost:8080/reset-password`
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
[#166789952](https://www.pivotaltracker.com/story/show/166789952)
#### Screenshots (if appropriate)
- Validation
<img width="695" alt="Screen Shot 2019-09-01 at 18 40 46" src="https://user-images.githubusercontent.com/30776949/64079460-13500100-cce8-11e9-9a57-c1c611c2392c.png">
<img width="688" alt="Screen Shot 2019-09-01 at 18 42 04" src="https://user-images.githubusercontent.com/30776949/64079485-42667280-cce8-11e9-9d93-01be750b80d9.png">
<img width="675" alt="Screen Shot 2019-09-01 at 18 43 07" src="https://user-images.githubusercontent.com/30776949/64079500-66c24f00-cce8-11e9-8bb3-d8cfe72b9e79.png">

- Successfully reset password
<img width="709" alt="Screen Shot 2019-09-03 at 08 18 10" src="https://user-images.githubusercontent.com/30776949/64148366-6f6b7000-ce23-11e9-8c85-49d8b6cf0d2f.png">



#### Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I don't have more than 3 major commits on this PR